### PR TITLE
TAVERNA-990

### DIFF
--- a/taverna-configuration-impl/src/main/java/org/apache/taverna/workbench/ui/impl/configuration/WorkbenchConfigurationImpl.java
+++ b/taverna-configuration-impl/src/main/java/org/apache/taverna/workbench/ui/impl/configuration/WorkbenchConfigurationImpl.java
@@ -168,7 +168,7 @@ public class WorkbenchConfigurationImpl extends AbstractConfigurable implements
 	private String getDefaultDotLocation() {
 		if (applicationConfiguration == null)
 			return null;
-		File startupDir = applicationConfiguration.getStartupDir();
+		File startupDir = applicationConfiguration.getStartupDir().toFile();
 		if (startupDir == null)
 			return DOT_FALLBACK;
 


### PR DESCRIPTION
applicationConfiguration.getStartupDir() is returning Path object although "startupDir" is a File object. In order to fix this "toFile" method in " java.nio.file.Path" API is called which will return a File object.